### PR TITLE
Removal of identical data in similarity command

### DIFF
--- a/default/data/ui/views/similarity.xml
+++ b/default/data/ui/views/similarity.xml
@@ -87,6 +87,13 @@
       <default>false</default>
       <initialValue>false</initialValue>
     </input>
+    <input id="horiz_two_radio_2" type="radio" token="remove_duplicates">
+      <label>Remove duplicates value in multivalued to multivalued fields comparison</label>
+      <choice value="false">No</choice>
+      <choice value="true">Yes</choice>
+      <default>false</default>
+      <initialValue>false</initialValue>
+    </input>
   </fieldset>
   <row>
     <panel>
@@ -235,7 +242,7 @@ All algorithms return a distance and similarity score between 0 and 1, while som
         <search>
           <query>| makeresults
 | eval text=if(match("$text$",","),split("$text$",","),"$text$"), compare=if(match("$compare$",","),split("$compare$",","),"$compare$")
-| similarity textfield=text comparefield=compare algo=$algo$ limit=$limit$ mvzip=$mvzip$
+| similarity textfield=text comparefield=compare algo=$algo$ limit=$limit$ mvzip=$mvzip$ remove_duplicates=$remove_duplicates$
 | fields - _time
 | table text compare *</query>
           <earliest>-24h@h</earliest>

--- a/default/searchbnf.conf
+++ b/default/searchbnf.conf
@@ -24,7 +24,7 @@ usage = public
 example1 = * | cleantext textfield=sentence
 
 [similarity-command]
-syntax = similarity textfield=<field> comparefield=<field> (algo=<similarity_algo-options>)? (limit=<int>)? (mvzip=<bool>)?
+syntax = similarity textfield=<field> comparefield=<field> (algo=<similarity_algo-options>)? (limit=<int>)? (mvzip=<bool>)? (remove_duplicates=<bool>)?
 shortdesc = Returns distance and similarity scores between 0 and 1. Some algorithms also return number of steps to make text the same.
 description = Returns distance and similarity scores between 0 and 1. \
     Some algorithms also return number of steps to make text the same. \


### PR DESCRIPTION
Here is a PR for issue #5, 

- I have changed the if statement to use the new argument in the command similarity (remove_duplicates)
- Homogeneity in the command output: We didn't have all the columns present in the multi-to-multi output for single-to-single or single-to-multi output : 

Before : 
Columns top_match_target and top_match_source present for muti-to-multi output
Column top_match_target and present for single-to-multi output
Neither column top_match_target or top_match_source present for single-to-single output

All these random present or not columns are a pain to automate if we want to use this command on a huge output of text-to-text comparison with a random number of comparisons to do.

So with this PR, I propose that we have a similar output for each possible output "type" so 

After : 
Columns top_match_target and top_match_source present for muti-to-multi output
Columns top_match_target and top_match_source present for single-to-multi output
Columns top_match_target and top_match_source present for single-to-single output

- Added an option in the similarity view for removing or not duplicates in the data